### PR TITLE
Agrego cambios de configuración del tráfico en el workflow y el makefile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,5 +48,7 @@ jobs:
       #----------------------------------------------
       - name: Run tests
         run: |
+            ./loss.sh up
             source .venv/bin/activate
             pytest tests
+            ./loss.sh down

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ FLAKE8=$(POETRY) run flake8
 PYTEST=$(POETRY) run pytest
 PACKAGE=src
 TESTS=tests
+LOSS=./loss.sh
 
 install:
 	$(POETRY) install
@@ -19,5 +20,13 @@ lint: fmt
 
 test:
 	$(PYTEST) ./${TESTS}
+
+loss-up:
+	$(LOSS) up
+
+loss-down:
+	$(LOSS) down
+
+test-loss : loss-up test loss-down
 
 all: lint test

--- a/loss.sh
+++ b/loss.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+usage() {
+	echo "Usage: loss [options] (up|down)"
+	echo "  -d, --device"
+	echo "  -l, --latency"
+	echo "  -b, --bandwidth"
+	echo "  -p, --packet-loss"
+}
+
+unknown() {
+	echo "Error: Unknown parameter: $1"
+	echo
+	usage $1
+}
+
+exe() {
+	echo $1
+	if ! $1; then
+    	exit 1
+	fi
+}
+
+
+device=lo      # interface
+latency=100    # ms of latency
+bandwidth=1000 # Kbps of bandwidth
+packetloss=10  # percentage of packets to drop
+up=0
+down=0
+
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -d|--device) device="$2"; shift ;;
+        -l|--latency) latency="$2" ; shift ;;
+        -b|--bandwidth) bandwidth="$2" ; shift ;;
+        -p|--packet-loss) packetloss="$2" ; shift ;;
+        up) up=1 ; shift ;;
+        down) down=1 ; shift ;;
+        *) unknown $1; exit 1 ;;
+    esac
+    shift
+done
+
+
+if [ $up == $down ]
+then
+	usage
+	exit
+fi
+
+
+options="latency ${latency}ms  rate ${bandwidth}kbit loss ${packetloss}"
+
+
+if [ $up == 1 ]
+then
+	exe "sudo tc qdisc add dev ${device} root netem ${options}"
+	exe "sudo tc qdisc show dev ${device}"
+else
+	exe "sudo tc qdisc del dev ${device} root netem ${options}"
+	exe "sudo tc qdisc show dev ${device}"
+fi
+

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -25,4 +25,4 @@ def test_download_medium():
 
 
 def test_download_big():
-    assert download(10_000_000) == 0
+    assert download(2_000_000) == 0

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -24,4 +24,4 @@ def test_upload_medium():
 
 
 def test_upload_big():
-    assert upload(10_000_000) == 0
+    assert upload(2_000_000) == 0


### PR DESCRIPTION
Las pruebas con pérdida se ejecutan así:
```
make test-loss
```
Y de ser necesario, se puede reestablecer la configuración del tráfico con:
```
make loss-down
```
Por lo que,
```
make loss-up
make test
make loss-down
```
Es equivalente a:
```
make test-loss
```
El script `loss.sh` se usa así:
```
Usage: loss [options] (up|down)
  -d, --device
  -l, --latency
  -b, --bandwidth
  -p, --packet-loss
```